### PR TITLE
feat: detect missing comment on `mapped_column`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ class Users(Base):
     name = Column(String, comment="User name: first, middle, last")
 ```
 
+Also applies to `mapped_column`:
+
+```python
+class Users(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, comment="User ID from Auth Service")
+    name = mapped_column(String, comment="User name: first, middle, last")
+```
+
 ## License
 
 This project is licensed under the terms of the MIT license.

--- a/flake8_sqlalchemy/checkers/column_comment.py
+++ b/flake8_sqlalchemy/checkers/column_comment.py
@@ -15,7 +15,9 @@ class SQA200(Issue):
 class ColumnCommentChecker(Checker):
     def run(self, node: ast.Call) -> List[Issue]:
         """
-        Checks if a `sqlalchemy.Column` is missing a `comment` keyword argument.
+        Checks if a column is missing a `comment` keyword argument on:
+        - `sqlalchemy.Column`
+        - `sqlalchemy.orm.mapped_column`
         """
         issues: List[Issue] = []
 
@@ -26,9 +28,7 @@ class ColumnCommentChecker(Checker):
 
     def is_column(self, node: ast.Call) -> bool:
         call_name = self.get_call_name(node)
-        if call_name == "Column":
-            return True
-        return False
+        return call_name in ["Column", "mapped_column"]
 
     def has_comment(self, node: ast.Call) -> bool:
         return self.has_keyword(node, "comment")

--- a/tests/checkers/test_column_comment.py
+++ b/tests/checkers/test_column_comment.py
@@ -24,3 +24,33 @@ def test_column_comment_missing_fails(helpers):
         "5:12 SQA200 Column missing comment keyword argument",
         "6:12 SQA200 Column missing comment keyword argument",
     }
+
+
+class TestSqlAlchemyDeclarativeModel:
+    def test_mapped_column_passes(self, helpers):
+        sample_code = """
+            from sqlalchemy.orm import DeclarativeBase, mapped_column
+
+            class Base(DeclarativeBase):
+                pass
+
+            class MyModel(Base):
+                column = mapped_column(comment="Super Important!")
+        """
+        assert helpers.results(dedent(sample_code)) == set()
+
+    def test_mapped_column_missing_fails(self, helpers):
+        sample_code = """
+            from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+            class Base(DeclarativeBase):
+                pass
+
+            class MyModel(Base):
+                column: Mapped[str] = mapped_column()
+                unique_column: Mapped[str] = mapped_column(unique=True)
+        """
+        assert helpers.results(dedent(sample_code)) == {
+            "8:27 SQA200 Column missing comment keyword argument",
+            "9:34 SQA200 Column missing comment keyword argument",
+        }


### PR DESCRIPTION
Using SQLAlchemy 2.0 Declarative ORM, we should now detect missing comments on `mapped_column()` instances as well.