### PR TITLE
Add checker for relationship backref usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,34 @@ class Users(Base):
     name = mapped_column(String, comment="User name: first, middle, last")
 ```
 
+### `SQA300` - Use `back_populates` instead of `backref` in relationship
+
+Encourages the use of `back_populates` instead of `backref` in SQLAlchemy relationships to ensure clarity and consistency in bidirectional relationships.
+
+#### Bad
+
+```python
+class Parent(Base):
+    __tablename__ = "parent"
+    id = Column(Integer, primary_key=True)
+    children = relationship("Child", backref="parent")
+```
+
+#### Good
+
+```python
+class Parent(Base):
+    __tablename__ = "parent"
+    id = Column(Integer, primary_key=True)
+    children = relationship("Child", back_populates="parent")
+
+class Child(Base):
+    __tablename__ = "child"
+    id = Column(Integer, primary_key=True)
+    parent_id = Column(Integer, ForeignKey("parent.id"))
+    parent = relationship("Parent", back_populates="children")
+```
+
 ## License
 
 This project is licensed under the terms of the MIT license.

--- a/flake8_sqlalchemy/checkers/__init__.py
+++ b/flake8_sqlalchemy/checkers/__init__.py
@@ -1,7 +1,9 @@
 from .column_comment import ColumnCommentChecker
 from .import_alias import ImportAliasChecker
+from .relationship_backref_checker import RelationshipBackrefChecker
 
 __all__ = (
     "ColumnCommentChecker",
     "ImportAliasChecker",
+    "RelationshipBackrefChecker",
 )

--- a/flake8_sqlalchemy/checkers/relationship_backref_checker.py
+++ b/flake8_sqlalchemy/checkers/relationship_backref_checker.py
@@ -3,8 +3,8 @@
 import ast
 from typing import List
 
-from ._base import Checker
 from ..issue import Issue
+from ._base import Checker
 
 
 class SQA300(Issue):

--- a/flake8_sqlalchemy/checkers/relationship_backref_checker.py
+++ b/flake8_sqlalchemy/checkers/relationship_backref_checker.py
@@ -1,0 +1,39 @@
+"""Checker for detecting `backref` usage in SQLAlchemy relationships."""
+
+import ast
+from typing import List
+
+from ._base import Checker
+from ..issue import Issue
+
+
+class SQA300(Issue):
+    code = "SQA300"
+    message = f"{code} Use `back_populates` instead of `backref` in relationship"
+
+
+class RelationshipBackrefChecker(Checker):
+    def run(self, node: ast.Call) -> List[Issue]:
+        """
+        Checks if a relationship() call uses `backref` and suggests `back_populates` instead.
+        """
+        issues: List[Issue] = []
+
+        if self.is_relationship_with_backref(node):
+            issues.append(SQA300(node.lineno, node.col_offset))
+
+        return issues
+
+    @staticmethod
+    def is_relationship_with_backref(node: ast.Call) -> bool:
+        """
+        Determines if the given node represents a relationship() call with a `backref` argument.
+        """
+        if RelationshipBackrefChecker.get_call_name(node) != "relationship":
+            return False
+
+        for keyword in node.keywords:
+            if keyword.arg == "backref":
+                return True
+
+        return False

--- a/flake8_sqlalchemy/checkers/relationship_backref_checker.py
+++ b/flake8_sqlalchemy/checkers/relationship_backref_checker.py
@@ -15,7 +15,8 @@ class SQA300(Issue):
 class RelationshipBackrefChecker(Checker):
     def run(self, node: ast.Call) -> List[Issue]:
         """
-        Checks if a relationship() call uses `backref` and suggests `back_populates` instead.
+        Checks if a relationship() call uses `backref` and suggests
+        `back_populates` instead.
         """
         issues: List[Issue] = []
 
@@ -27,7 +28,8 @@ class RelationshipBackrefChecker(Checker):
     @staticmethod
     def is_relationship_with_backref(node: ast.Call) -> bool:
         """
-        Determines if the given node represents a relationship() call with a `backref` argument.
+        Determines if the given node represents a relationship() call with a
+        `backref` argument.
         """
         if RelationshipBackrefChecker.get_call_name(node) != "relationship":
             return False

--- a/flake8_sqlalchemy/plugin.py
+++ b/flake8_sqlalchemy/plugin.py
@@ -2,7 +2,7 @@ import ast
 import importlib.metadata
 from typing import Any, Dict, Generator, List, Tuple, Type
 
-from .checkers import ColumnCommentChecker, ImportAliasChecker
+from .checkers import ColumnCommentChecker, ImportAliasChecker, RelationshipBackrefChecker
 from .issue import Issue
 
 
@@ -10,6 +10,7 @@ class Visitor(ast.NodeVisitor):
     checkers: Dict[str, List[Any]] = {
         "Call": [
             ColumnCommentChecker(),
+            RelationshipBackrefChecker(),
         ],
         "Import": [
             ImportAliasChecker(),

--- a/flake8_sqlalchemy/plugin.py
+++ b/flake8_sqlalchemy/plugin.py
@@ -2,7 +2,11 @@ import ast
 import importlib.metadata
 from typing import Any, Dict, Generator, List, Tuple, Type
 
-from .checkers import ColumnCommentChecker, ImportAliasChecker, RelationshipBackrefChecker
+from .checkers import (
+    ColumnCommentChecker,
+    ImportAliasChecker,
+    RelationshipBackrefChecker,
+)
 from .issue import Issue
 
 

--- a/tests/checkers/test_relationship_backref_checker.py
+++ b/tests/checkers/test_relationship_backref_checker.py
@@ -1,5 +1,6 @@
 from textwrap import dedent
 
+
 def test_relationship_backref_passes(helpers):
     sample_code = """
         from sqlalchemy.orm import relationship
@@ -11,6 +12,7 @@ def test_relationship_backref_passes(helpers):
             parent = relationship("Parent", back_populates="children")
     """
     assert helpers.results(dedent(sample_code)) == set()
+
 
 def test_relationship_backref_fails(helpers):
     sample_code = """

--- a/tests/checkers/test_relationship_backref_checker.py
+++ b/tests/checkers/test_relationship_backref_checker.py
@@ -1,0 +1,28 @@
+from textwrap import dedent
+
+def test_relationship_backref_passes(helpers):
+    sample_code = """
+        from sqlalchemy.orm import relationship
+
+        class Parent:
+            children = relationship("Child", back_populates="parent")
+
+        class Child:
+            parent = relationship("Parent", back_populates="children")
+    """
+    assert helpers.results(dedent(sample_code)) == set()
+
+def test_relationship_backref_fails(helpers):
+    sample_code = """
+        from sqlalchemy.orm import relationship
+
+        class Parent:
+            children = relationship("Child", backref="parent")
+
+        class Child:
+            parent = relationship("Parent", backref="children")
+    """
+    assert helpers.results(dedent(sample_code)) == {
+        "5:16 SQA300 Use `back_populates` instead of `backref` in relationship",
+        "8:14 SQA300 Use `back_populates` instead of `backref` in relationship",
+    }


### PR DESCRIPTION
Related to #25

This pull request introduces a new checker to the flake8-sqlalchemy plugin that detects the use of `backref` in SQLAlchemy `relationship()` calls and recommends using `back_populates` instead. This change aims to encourage best practices in SQLAlchemy relationship definitions.

- **Implements a new checker**: Adds `RelationshipBackrefChecker` in `flake8_sqlalchemy/checkers/relationship_backref_checker.py` to scan for `relationship()` calls that use `backref` and suggest `back_populates`.
- **Updates plugin architecture**: Modifies `flake8_sqlalchemy/checkers/__init__.py` and `flake8_sqlalchemy/plugin.py` to include the new `RelationshipBackrefChecker` in the list of checkers and in the visitor's checker dictionary, respectively.
- **Adds tests**: Introduces tests in `tests/checkers/test_relationship_backref_checker.py` to verify that the checker accurately identifies `relationship()` calls with `backref` and does not raise false positives for those using `back_populates`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/miketheman/flake8-sqlalchemy/issues/25?shareId=f2e88734-98ec-401f-95db-1e5fed8d2a56).