### PR TITLE
Add GitHub Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Related to #37

Adds a GitHub Dependabot configuration file to the repository to automate dependency updates.
- **Configuration Details**: The `.github/dependabot.yml` file specifies Dependabot to check for updates to both the `pip` and `github-actions` ecosystems on a weekly basis.
- **Pull Request Limits**: Configures Dependabot to open up to 10 pull requests for version updates, ensuring the repository dependencies remain secure and up-to-date without overwhelming the project maintainers.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/miketheman/flake8-sqlalchemy/issues/37?shareId=38c9ea36-1309-4452-b12c-65bdb7d3a55c).