### PR TITLE
Group all Python package updates into a single Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     groups:
-      - name: "all"
-        patterns: ["*"]
+      name: "all"
+      patterns: ["*"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      - name: "all"
+        patterns: ["*"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Updates the Dependabot configuration to group all Python package updates into a single pull request.
- Adds a `groups` section under the `pip` package-ecosystem in the `.github/dependabot.yml` file.
- Defines a group named `all` within the `groups` section.
- Sets `patterns` to `["*"]` under the `all` group to match all packages, enabling the grouping of all Python package updates into a single pull request.
- Keeps the configuration for the `github-actions` package-ecosystem unchanged.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/miketheman/flake8-sqlalchemy?shareId=d654c3ca-33de-408c-978f-7e45c9f49c2e).